### PR TITLE
Remove unneeded copying.

### DIFF
--- a/autocorr/multitau.py
+++ b/autocorr/multitau.py
@@ -27,11 +27,11 @@ def multitau(signal, lags_per_level=16):
     # 1-D data hack
     if len(signal.shape) == 1:
         N = even(signal.shape[0])
-        a = np.array(signal[np.newaxis, :N], copy=True)
+        a = signal[np.newaxis, :N]
     elif len(signal.shape) == 2:
         # copy data a local array
         N = even(signal.shape[1])
-        a = np.array(signal[:, :N], copy=True)
+        a = signal[:, :N]
     elif len(signal.shape) > 2:
         raise ValueError('Flatten the [2,3,..] dimensions before passing to autocorrelate.')
 

--- a/autocorr/multitau.py
+++ b/autocorr/multitau.py
@@ -25,14 +25,14 @@ def multitau(signal, lags_per_level=16):
         return x if x % 2 == 0 else x - 1
 
     # 1-D data hack
-    if len(signal.shape) == 1:
+    if signal.ndim == 1:
         N = even(signal.shape[0])
         a = signal[np.newaxis, :N]
-    elif len(signal.shape) == 2:
+    elif signal.ndim == 2:
         # copy data a local array
         N = even(signal.shape[1])
         a = signal[:, :N]
-    elif len(signal.shape) > 2:
+    elif signal.ndim > 2:
         raise ValueError('Flatten the [2,3,..] dimensions before passing to autocorrelate.')
 
     if N < lags_per_level:

--- a/autocorr/tests/test_multitau.py
+++ b/autocorr/tests/test_multitau.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_array_equal
 import autocorr
 import time
 
@@ -6,12 +7,15 @@ N = 10240
 np.random.seed(0)
 t = np.arange(N)
 A = np.exp(-0.05 * t)[:, np.newaxis] + np.random.rand(N, 24) * 0.1
+original = A.copy()
 
 
 def test_multitau():
     t0 = time.time()
     g1, tau = autocorr.multitau(A.T, 16)
     t1 = time.time()
+    # Check that the input array has not been mutated.
+    assert_array_equal(A, original)
     print('pure python time = %f' % (t1 - t0))
 
 
@@ -19,6 +23,8 @@ def test_multitau_mt():
     t0 = time.time()
     g1, tau = autocorr.multitau_mt(A.T, 16)
     t1 = time.time()
+    # Check that the input array has not been mutated.
+    assert_array_equal(A, original)
     print('accelerated version = %f' % (t1 - t0))
 
 
@@ -26,6 +32,8 @@ def test_fftautocorr():
     t0 = time.time()
     g2, tau = autocorr.fftautocorr(A.T)
     t1 = time.time()
+    # Check that the input array has not been mutated.
+    assert_array_equal(A, original)
     print('fft version = %f' % (t1 - t0))
 
 
@@ -33,4 +41,6 @@ def test_cfftautocorr():
     t0 = time.time()
     g2, tau = autocorr.fftautocorr_mt(A.T)
     t1 = time.time()
+    # Check that the input array has not been mutated.
+    assert_array_equal(A, original)
     print('fft version = %f' % (t1 - t0))


### PR DESCRIPTION
When algorithm operates by modifying the input array in place, it is
good manners to make a copy first so that the function does not mutate
user input. I am guessing that that was the motivation for the use of
`copy()` here.

However, as far as I can tell, this algorithm does not modify `signal`
(or its alias `a`) in place. It reassigns the variable `a` in a loop,
but does not actually modify the input array object.

Therefore, we can remove this copying and increase the speed. Also, note
that the call to `np.array` explicitly cast the input to a literal numpy
array. By removing that from the code, we accept dask arrays and cupy
arrays and sparse arrays and allow them to flow through the algorithm via the NEP-18 numpy
dispatch mechanism. (See [this section of the numpy documentation](https://docs.scipy.org/doc/numpy/user/basics.dispatch.html#basics-dispatch),
written by me as it happens, for details.)

attn @leofang @aryabhatt 